### PR TITLE
Fixed syntax error in project toml preventing installation via pixi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">= 3.9"
 license = {file = "LICENSE"}
 authors = [
-    {name = "Gonzalez, Raffa", email = "rcgonzalez@g.hmc.edu"}
+    {name = "Gonzalez, Raffa", email = "rcgonzalez@g.hmc.edu"},
     {name = "Spencer, Matthew", email = "mespence@gmail.com"}
 ]
 dependencies = ["numpy", "scipy"]


### PR DESCRIPTION
Simple fix to pyproject toml that was preventing installation via pixi (as described in README) from succeeding.